### PR TITLE
URL Cleanup

### DIFF
--- a/cloudfoundry/runCFAcceptanceTests.sh
+++ b/cloudfoundry/runCFAcceptanceTests.sh
@@ -18,9 +18,9 @@ popd () {
 
 function prepare_jdbc_log_with_rabbit_binder() {
 
-    wget -O /tmp/jdbc-source-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/jdbc-source-rabbit/2.1.0.BUILD-SNAPSHOT/jdbc-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/jdbc-source-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/jdbc-source-rabbit/2.1.0.BUILD-SNAPSHOT/jdbc-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/log-sink-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/log-sink-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -48,11 +48,11 @@ function prepare_jdbc_log_with_rabbit_binder() {
 
 function prepare_http_transform_log_with_rabbit_binder() {
 
-    wget -O /tmp/http-source-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/http-source-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/transform-processor-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/transform-processor-rabbit/2.1.0.BUILD-SNAPSHOT/transform-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/transform-processor-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/transform-processor-rabbit/2.1.0.BUILD-SNAPSHOT/transform-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/log-sink-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/log-sink-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -88,11 +88,11 @@ function prepare_http_transform_log_with_rabbit_binder() {
 
 function prepare_http_splitter_log_with_rabbit_binder() {
 
-    wget -O /tmp/http-source-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/http-source-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/splitter-processor-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/splitter-processor-rabbit/2.1.0.BUILD-SNAPSHOT/splitter-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/splitter-processor-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/splitter-processor-rabbit/2.1.0.BUILD-SNAPSHOT/splitter-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/log-sink-rabbit.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/log-sink-rabbit.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -128,9 +128,9 @@ function prepare_http_splitter_log_with_rabbit_binder() {
 
 function prepare_ticktock_latest_with_rabbit_binder() {
 
-    wget -O /tmp/ticktock-time-source.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/time-source-rabbit/2.1.0.BUILD-SNAPSHOT/time-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/ticktock-time-source.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/time-source-rabbit/2.1.0.BUILD-SNAPSHOT/time-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
-    wget -O /tmp/ticktock-log-sink.jar http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
+    wget -O /tmp/ticktock-log-sink.jar https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -158,9 +158,9 @@ function prepare_ticktock_latest_with_rabbit_binder() {
 
 function prepare_ticktock_13_with_rabbit_binder() {
 
-    wget -O /tmp/ticktock-time-source131.jar http://repo.spring.io/release/org/springframework/cloud/stream/app/time-source-rabbit/1.3.1.RELEASE/time-source-rabbit-1.3.1.RELEASE.jar
+    wget -O /tmp/ticktock-time-source131.jar https://repo.spring.io/release/org/springframework/cloud/stream/app/time-source-rabbit/1.3.1.RELEASE/time-source-rabbit-1.3.1.RELEASE.jar
 
-    wget -O /tmp/ticktock-log-sink131.jar http://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar
+    wget -O /tmp/ticktock-log-sink131.jar https://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -188,7 +188,7 @@ function prepare_ticktock_13_with_rabbit_binder() {
 
 function prepare_uppercase_transformer_with_rabbit_binder() {
 
-    wget -O /tmp/uppercase-transformer-rabbit.jar http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/uppercase-transformer-rabbit/0.0.1-SNAPSHOT/uppercase-transformer-rabbit-0.0.1-SNAPSHOT.jar
+    wget -O /tmp/uppercase-transformer-rabbit.jar https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/uppercase-transformer-rabbit/0.0.1-SNAPSHOT/uppercase-transformer-rabbit-0.0.1-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then
@@ -208,8 +208,8 @@ function prepare_uppercase_transformer_with_rabbit_binder() {
 
 function prepare_partitioning_test_with_rabbit_binder() {
 
-    wget -O /tmp/partitioning-producer-rabbit.jar http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-producer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-producer-sample-rabbit-0.0.1-SNAPSHOT.jar
-    wget -O /tmp/partitioning-consumer-rabbit.jar http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-consumer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-consumer-sample-rabbit-0.0.1-SNAPSHOT.jar
+    wget -O /tmp/partitioning-producer-rabbit.jar https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-producer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-producer-sample-rabbit-0.0.1-SNAPSHOT.jar
+    wget -O /tmp/partitioning-consumer-rabbit.jar https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-consumer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-consumer-sample-rabbit-0.0.1-SNAPSHOT.jar
 
     if [ $6 == "skip-ssl-validation" ]
     then

--- a/custom-stream-apps/mvnw
+++ b/custom-stream-apps/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-consumer-sample-kafka/mvnw
+++ b/custom-stream-apps/partitioning-consumer-sample-kafka/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-consumer-sample-kafka/mvnw.cmd
+++ b/custom-stream-apps/partitioning-consumer-sample-kafka/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-consumer-sample-rabbit/mvnw
+++ b/custom-stream-apps/partitioning-consumer-sample-rabbit/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-consumer-sample-rabbit/mvnw.cmd
+++ b/custom-stream-apps/partitioning-consumer-sample-rabbit/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-producer-sample-kafka/mvnw
+++ b/custom-stream-apps/partitioning-producer-sample-kafka/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-producer-sample-kafka/mvnw.cmd
+++ b/custom-stream-apps/partitioning-producer-sample-kafka/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-producer-sample-rabbit/mvnw
+++ b/custom-stream-apps/partitioning-producer-sample-rabbit/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/partitioning-producer-sample-rabbit/mvnw.cmd
+++ b/custom-stream-apps/partitioning-producer-sample-rabbit/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/custom-stream-apps/pom.xml
+++ b/custom-stream-apps/pom.xml
@@ -75,7 +75,7 @@
         <repository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/libs-snapshot-local</url>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -86,7 +86,7 @@
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.spring.io/libs-milestone-local</url>
+            <url>https://repo.spring.io/libs-milestone-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -94,7 +94,7 @@
         <repository>
             <id>spring-releases</id>
             <name>Spring Releases</name>
-            <url>http://repo.spring.io/release</url>
+            <url>https://repo.spring.io/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -104,7 +104,7 @@
         <pluginRepository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/libs-snapshot-local</url>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -115,7 +115,7 @@
         <pluginRepository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.spring.io/libs-milestone-local</url>
+            <url>https://repo.spring.io/libs-milestone-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -123,7 +123,7 @@
         <pluginRepository>
             <id>spring-releases</id>
             <name>Spring Releases</name>
-            <url>http://repo.spring.io/libs-release-local</url>
+            <url>https://repo.spring.io/libs-release-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/custom-stream-apps/uppercase-transformer-kafka/mvnw
+++ b/custom-stream-apps/uppercase-transformer-kafka/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/uppercase-transformer-kafka/mvnw.cmd
+++ b/custom-stream-apps/uppercase-transformer-kafka/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/custom-stream-apps/uppercase-transformer-rabbit/mvnw
+++ b/custom-stream-apps/uppercase-transformer-rabbit/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/custom-stream-apps/uppercase-transformer-rabbit/mvnw.cmd
+++ b/custom-stream-apps/uppercase-transformer-rabbit/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-consumer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-consumer-sample-rabbit-0.0.1-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-consumer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-consumer-sample-rabbit-0.0.1-SNAPSHOT.jar ([https](https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-consumer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-consumer-sample-rabbit-0.0.1-SNAPSHOT.jar) result 200).
* http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-producer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-producer-sample-rabbit-0.0.1-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-producer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-producer-sample-rabbit-0.0.1-SNAPSHOT.jar ([https](https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/partitioning-producer-sample-rabbit/0.0.1-SNAPSHOT/partitioning-producer-sample-rabbit-0.0.1-SNAPSHOT.jar) result 200).
* http://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/uppercase-transformer-rabbit/0.0.1-SNAPSHOT/uppercase-transformer-rabbit-0.0.1-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/uppercase-transformer-rabbit/0.0.1-SNAPSHOT/uppercase-transformer-rabbit-0.0.1-SNAPSHOT.jar ([https](https://repo.spring.io/libs-snapshot-local/io/spring/cloud/stream/acceptance/uppercase-transformer-rabbit/0.0.1-SNAPSHOT/uppercase-transformer-rabbit-0.0.1-SNAPSHOT.jar) result 200).
* http://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar migrated to:  
  https://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar ([https](https://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar) result 200).
* http://repo.spring.io/release/org/springframework/cloud/stream/app/time-source-rabbit/1.3.1.RELEASE/time-source-rabbit-1.3.1.RELEASE.jar migrated to:  
  https://repo.spring.io/release/org/springframework/cloud/stream/app/time-source-rabbit/1.3.1.RELEASE/time-source-rabbit-1.3.1.RELEASE.jar ([https](https://repo.spring.io/release/org/springframework/cloud/stream/app/time-source-rabbit/1.3.1.RELEASE/time-source-rabbit-1.3.1.RELEASE.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/2.1.0.BUILD-SNAPSHOT/http-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/jdbc-source-rabbit/2.1.0.BUILD-SNAPSHOT/jdbc-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/jdbc-source-rabbit/2.1.0.BUILD-SNAPSHOT/jdbc-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/jdbc-source-rabbit/2.1.0.BUILD-SNAPSHOT/jdbc-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.0.BUILD-SNAPSHOT/log-sink-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/splitter-processor-rabbit/2.1.0.BUILD-SNAPSHOT/splitter-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/splitter-processor-rabbit/2.1.0.BUILD-SNAPSHOT/splitter-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/splitter-processor-rabbit/2.1.0.BUILD-SNAPSHOT/splitter-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/time-source-rabbit/2.1.0.BUILD-SNAPSHOT/time-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/time-source-rabbit/2.1.0.BUILD-SNAPSHOT/time-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/time-source-rabbit/2.1.0.BUILD-SNAPSHOT/time-source-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/transform-processor-rabbit/2.1.0.BUILD-SNAPSHOT/transform-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar migrated to:  
  https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/transform-processor-rabbit/2.1.0.BUILD-SNAPSHOT/transform-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/snapshot/org/springframework/cloud/stream/app/transform-processor-rabbit/2.1.0.BUILD-SNAPSHOT/transform-processor-rabbit-2.1.0.BUILD-SNAPSHOT.jar) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://repo.spring.io/libs-milestone-local migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release-local migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/libs-snapshot-local migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance