### PR TITLE
URL Cleanup

### DIFF
--- a/custom-stream-apps/partitioning-consumer-sample-kafka/src/main/java/demo/PartitioningKafkaDemo.java
+++ b/custom-stream-apps/partitioning-consumer-sample-kafka/src/main/java/demo/PartitioningKafkaDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-consumer-sample-kafka/src/main/java/demo/PartitioningKafkaDemoApplication.java
+++ b/custom-stream-apps/partitioning-consumer-sample-kafka/src/main/java/demo/PartitioningKafkaDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-consumer-sample-kafka/src/test/java/demo/ModuleApplicationTests.java
+++ b/custom-stream-apps/partitioning-consumer-sample-kafka/src/test/java/demo/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-consumer-sample-rabbit/src/main/java/demo/PartitioningRabbitDemo.java
+++ b/custom-stream-apps/partitioning-consumer-sample-rabbit/src/main/java/demo/PartitioningRabbitDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-consumer-sample-rabbit/src/main/java/demo/PartitioningRabbitDemoApplication.java
+++ b/custom-stream-apps/partitioning-consumer-sample-rabbit/src/main/java/demo/PartitioningRabbitDemoApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-consumer-sample-rabbit/src/test/java/demo/ModuleApplicationTests.java
+++ b/custom-stream-apps/partitioning-consumer-sample-rabbit/src/test/java/demo/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-producer-sample-kafka/src/test/java/demo/producer/ModuleApplicationTests.java
+++ b/custom-stream-apps/partitioning-producer-sample-kafka/src/test/java/demo/producer/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/partitioning-producer-sample-rabbit/src/test/java/demo/producer/ModuleApplicationTests.java
+++ b/custom-stream-apps/partitioning-producer-sample-rabbit/src/test/java/demo/producer/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-kafka/src/main/java/demo/UppercaseTransformer.java
+++ b/custom-stream-apps/uppercase-transformer-kafka/src/main/java/demo/UppercaseTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-kafka/src/main/java/demo/UppercaseTransformerApplication.java
+++ b/custom-stream-apps/uppercase-transformer-kafka/src/main/java/demo/UppercaseTransformerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-kafka/src/test/java/demo/ModuleApplicationTests.java
+++ b/custom-stream-apps/uppercase-transformer-kafka/src/test/java/demo/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-rabbit/src/main/java/demo/UppercaseTransformer.java
+++ b/custom-stream-apps/uppercase-transformer-rabbit/src/main/java/demo/UppercaseTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-rabbit/src/main/java/demo/UppercaseTransformerApplication.java
+++ b/custom-stream-apps/uppercase-transformer-rabbit/src/main/java/demo/UppercaseTransformerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/custom-stream-apps/uppercase-transformer-rabbit/src/test/java/demo/ModuleApplicationTests.java
+++ b/custom-stream-apps/uppercase-transformer-rabbit/src/test/java/demo/ModuleApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/AbstractAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/AbstractAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/HttpSplitterLogAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/HttpSplitterLogAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/HttpTransformLogAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/HttpTransformLogAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/JdbcLogAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/JdbcLogAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/PartitioningAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/PartitioningAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/TickTock13AcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/TickTock13AcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/TickTockLatestAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/TickTockLatestAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/UppercaseTransformerAcceptanceTests.java
+++ b/spring-cloud-stream-acceptance-tests/src/test/java/sample/acceptance/tests/UppercaseTransformerAcceptanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 22 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).